### PR TITLE
chore: logic to blacklist chains

### DIFF
--- a/coins_details/coins_details.py
+++ b/coins_details/coins_details.py
@@ -121,6 +121,11 @@ WALLETS = coin_info.load_json(HERE / "wallets.json")
 OVERRIDES = coin_info.load_json(HERE / "coins_details.override.json")
 COINGECKO_IDS = coin_info.load_json(HERE / "coingecko_ids.json")
 DEFINITIONS_LATEST = coin_info.load_json(ROOT / "definitions-latest.json")
+DEFINITIONS_BLACKLIST = coin_info.load_json(HERE / "definitions-blacklist.json")
+
+DEFINITIONS_LATEST["networks"] = [
+    chain for chain in DEFINITIONS_LATEST["networks"] if chain.get("chain") not in DEFINITIONS_BLACKLIST["networks"]
+]
 
 # automatic wallet entries
 WALLETS_ETH_3RDPARTY = [
@@ -250,7 +255,11 @@ def main(verbose: int):
     assert len(chain_id_to_network) == len(eth_networks), "Duplicate network keys"
 
     for token in eth_tokens:
-        network = chain_id_to_network[token["chain_id"]]
+        network = chain_id_to_network.get(token["chain_id"])
+
+        if network is None:
+            continue 
+
         cdet = CoinDetail.from_eth_token(token, network)
         cg_ids_unfiltered.setdefault(cdet.coingecko_id, cdet).merge(cdet)
 

--- a/coins_details/definitions-blacklist.json
+++ b/coins_details/definitions-blacklist.json
@@ -1,0 +1,3 @@
+{
+    "networks": ["vechain"]
+}


### PR DESCRIPTION
VeChain (VET) is not a fully EVM-compatible blockchain, but it does have some level of EVM support. However, there is no way how to use Trezor which VeChain

<img width="1310" alt="Screenshot 2025-02-14 at 20 16 47" src="https://github.com/user-attachments/assets/bf796d9d-2722-4fe4-93cb-242e985f473e" />
