### PR TITLE
Clear signing: Raw, date constant token path, and other parsers.

### DIFF
--- a/eth_definitions/common.py
+++ b/eth_definitions/common.py
@@ -39,6 +39,28 @@ except ImportError as e:
     ) from None
 
 
+# A trezorlib that predates the ERC-7730 clear-signing proto additions (the
+# FORMATTER_RAW / FORMATTER_DATE enum members and the const_token_address field)
+# imports fine but is missing them — which would otherwise surface only as a
+# cryptic KeyError deep inside serialization. Fail fast with the same guidance.
+_missing_proto = [
+    f"EthereumERC7730FieldFormatterType.{name}"
+    for name in ("FORMATTER_RAW", "FORMATTER_DATE")
+    if not hasattr(EthereumERC7730FieldFormatterType, name)
+]
+if not any(
+    f.name == "const_token_address" for f in EthereumERC7730FieldInfo.FIELDS.values()
+):
+    _missing_proto.append("EthereumERC7730FieldInfo.const_token_address")
+if _missing_proto:
+    raise SystemExit(
+        "Your trezorlib is outdated — missing " + ", ".join(_missing_proto) + ".\n"
+        "The ERC-7730 clear-signing formatters need the updated proto. Run:\n"
+        "  uv pip install -e ../trezor-firmware/python\n"
+        "  uv run --no-sync ./do_update.sh"
+    )
+
+
 class SolanaTokenInfo(protobuf.MessageType):
     MESSAGE_WIRE_TYPE = None
     FIELDS = {

--- a/eth_definitions/common.py
+++ b/eth_definitions/common.py
@@ -182,6 +182,7 @@ class ERC7730Field(t.TypedDict):
     # TokenAmountFormatter params
     token_path: t.NotRequired[ERC7730Path]
     threshold: t.NotRequired[str]  # hex (no 0x prefix)
+    const_token_address: t.NotRequired[str]  # hex (no 0x prefix), 20 bytes
 
     # UnitFormatter params
     decimals: t.NotRequired[int]
@@ -364,6 +365,11 @@ def _build_erc7730_field_info(d: ERC7730Field) -> EthereumERC7730FieldInfo:
         decimals=d.get("decimals"),
         base=d.get("base"),
         prefix=d.get("prefix"),
+        const_token_address=(
+            bytes.fromhex(d["const_token_address"])
+            if "const_token_address" in d
+            else None
+        ),
     )
 
 

--- a/eth_definitions/erc7730.py
+++ b/eth_definitions/erc7730.py
@@ -411,6 +411,24 @@ def _resolve_constant(path_str: str, constants: dict[str, Any]) -> Any | None:
     return constants.get(parts[2])
 
 
+def _resolve_address_ref(value: Any, constants: dict[str, Any]) -> str | None:
+    """Resolve a token-address reference to normalized 20-byte hex (no `0x`).
+
+    ``value`` is a literal address string or a ``$.metadata.constants.*``
+    reference. Returns None if it can't be resolved to a valid 20-byte address.
+    """
+    s = str(value)
+    if s.startswith("$"):
+        resolved = _resolve_constant(s, constants)
+        if resolved is None:
+            return None
+        s = str(resolved)
+    s = _normalize_hex(s)
+    if len(s) != 40 or set(s) - _HEX_DIGITS:
+        return None
+    return s
+
+
 def _native_currency_includes_zero(
     params: dict[str, Any], constants: dict[str, Any]
 ) -> bool:
@@ -566,13 +584,27 @@ def build_field_dict(
                     f"{token_path_str} (field {label!r})",
                 )
         elif params.get("token"):
-            # A hardcoded `token` address isn't in calldata, and the proto only
-            # carries a `token_path`. Emitting this amount with no token would
-            # mislabel it as the chain's native currency, so skip the file.
-            raise UnsupportedFeature(
-                "tokenamount-hardcoded-token",
-                f"{params.get('token')} (field {label!r})",
-            )
+            # A hardcoded / constant token address isn't in calldata; the proto
+            # carries it directly as `const_token_address` (often a
+            # `$.metadata.constants.*` reference resolved here). The firmware uses
+            # it in place of a calldata-derived `token_path`.
+            const_addr = _resolve_address_ref(params["token"], constants)
+            if const_addr is None:
+                raise UnsupportedFeature(
+                    "invalid-const-token", f"{params['token']!r} (field {label!r})"
+                )
+            if int(const_addr, 16) == 0:
+                # The zero address is the null/native token, not a real ERC-20.
+                # Treat it like the no-token case: native if declared, else skip.
+                if _native_currency_includes_zero(params, constants):
+                    out["formatter"] = _FORMATTER_MAP["amount"]
+                else:
+                    raise UnsupportedFeature(
+                        "tokenamount-unknown-token",
+                        f"tokenAmount with null token (field {label!r})",
+                    )
+            else:
+                out["const_token_address"] = const_addr
         elif _native_currency_includes_zero(params, constants):
             # No `tokenPath`/`token`: the token defaults to the null address, and
             # the descriptor lists the zero address in `nativeCurrencyAddress`,
@@ -588,9 +620,9 @@ def build_field_dict(
                 "tokenamount-unknown-token",
                 f"tokenAmount with no token reference (field {label!r})",
             )
-        # `threshold` applies only to a real token amount; the native `AMOUNT`
-        # formatter ignores it on-device.
-        if "token_path" in out:
+        # `threshold` applies only to a real token amount (calldata- or
+        # constant-addressed); the native `AMOUNT` fallback ignores it on-device.
+        if "token_path" in out or "const_token_address" in out:
             threshold = params.get("threshold")
             if isinstance(threshold, str) and threshold.startswith("$"):
                 resolved_const = _resolve_constant(threshold, constants)

--- a/eth_definitions/erc7730.py
+++ b/eth_definitions/erc7730.py
@@ -219,19 +219,26 @@ _CONTAINER_MAP = {
 # Leaf-value kinds used for formatter ↔ type compatibility checks.
 KIND_ADDRESS = "address"
 KIND_NUMERIC = "numeric"  # any uint*
-KIND_OTHER = "other"  # bytes/bool/string/tuple/array/unknown — no formatter accepts it
+KIND_BYTES = "bytes"  # bool / bytesN / bytes / string — a scalar leaf only `raw` renders
+KIND_OTHER = "other"  # un-indexed array, tuple, or unknown — nothing renders it as one field
 
 
 def _classify_kind(base_type: str, array_depth: int) -> str:
     """Classify a resolved leaf Solidity type into a formatter-compat kind."""
     if array_depth > 0:
         # The leaf is still an array (e.g. an un-indexed `uint256[]`); no scalar
-        # formatter can render it.
+        # formatter can render it (a `.[]` iteration peels the dimension first).
         return KIND_OTHER
     if base_type == "address":
         return KIND_ADDRESS
     if base_type.startswith("uint"):
         return KIND_NUMERIC
+    if base_type == "bool" or base_type == "string" or base_type.startswith("bytes"):
+        # A scalar bool / bytesN / bytes / string leaf — the firmware's
+        # RawFormatter renders these (bytes as hex, bool as text, string as-is),
+        # but no other formatter does.
+        return KIND_BYTES
+    # tuple / unknown — not representable as a single rendered value.
     return KIND_OTHER
 
 
@@ -324,14 +331,25 @@ _FORMATTER_MAP = {
     "amount": "FORMATTER_AMOUNT",
     "tokenAmount": "FORMATTER_TOKEN_AMOUNT",
     "unit": "FORMATTER_UNIT",
+    # The firmware renders `raw` per Solidity type (int as decimal, address/bytes
+    # as hex, bool as text, string as-is) and `date` as a human-readable unix
+    # timestamp. A `date` with a `blockheight` encoding is overridden to RAW in
+    # build_field_dict, since it's a block number rather than a time.
+    "raw": "FORMATTER_RAW",
+    "date": "FORMATTER_DATE",
 }
 
-# The leaf-value kind each formatter expects the field's path to resolve to.
+# The leaf-value kind(s) each formatter accepts. A field whose path resolves to a
+# kind outside this set is unrepresentable, so the descriptor is skipped.
 _FORMATTER_VALUE_KIND = {
-    "addressName": KIND_ADDRESS,
-    "amount": KIND_NUMERIC,
-    "tokenAmount": KIND_NUMERIC,
-    "unit": KIND_NUMERIC,
+    "addressName": frozenset({KIND_ADDRESS}),
+    "amount": frozenset({KIND_NUMERIC}),
+    "tokenAmount": frozenset({KIND_NUMERIC}),
+    "unit": frozenset({KIND_NUMERIC}),
+    # `raw` renders any scalar leaf; only whole arrays / tuples are rejected.
+    "raw": frozenset({KIND_ADDRESS, KIND_NUMERIC, KIND_BYTES}),
+    # `date` paths point at a uint timestamp/blockheight.
+    "date": frozenset({KIND_NUMERIC}),
 }
 
 
@@ -520,12 +538,12 @@ def build_field_dict(
     if fmt not in _FORMATTER_MAP:
         raise UnsupportedFeature("unsupported-formatter", f"{fmt} (field {label!r})")
 
-    expected_kind = _FORMATTER_VALUE_KIND.get(fmt)
-    if expected_kind is not None and value_kind != expected_kind:
+    allowed_kinds = _FORMATTER_VALUE_KIND.get(fmt)
+    if allowed_kinds is not None and value_kind not in allowed_kinds:
         raise UnsupportedFeature(
             "formatter-type-mismatch",
-            f"{fmt} expects {expected_kind} but {path_str!r} is {value_kind} "
-            f"(field {label!r})",
+            f"{fmt} expects {'/'.join(sorted(allowed_kinds))} but {path_str!r} is "
+            f"{value_kind} (field {label!r})",
         )
 
     out: ERC7730Field = {
@@ -618,6 +636,13 @@ def build_field_dict(
             out["base"] = str(params["base"])
         if params.get("prefix") is not None:
             out["prefix"] = bool(params["prefix"])
+    elif fmt == "date":
+        # FORMATTER_DATE renders a unix timestamp (seconds) as a human-readable
+        # date on-device. The `blockheight` encoding is a plain block number, not
+        # a time — the date formatter would misrender it — so fall back to the
+        # raw integer for anything other than a timestamp.
+        if params.get("encoding", "timestamp") != "timestamp":
+            out["formatter"] = _FORMATTER_MAP["raw"]
 
     return out
 

--- a/eth_definitions/erc7730.py
+++ b/eth_definitions/erc7730.py
@@ -251,9 +251,15 @@ def path_to_dict(
     used by the caller to check the field's formatter against the type the
     path actually points at.
 
+    A trailing `.[]` (whole-array iteration) is supported: the path points at
+    the array itself and the firmware formats each element. The peeled element
+    kind is returned, so formatter compatibility is checked against the element
+    type (e.g. `amounts.[]` over `uint256[]` is numeric).
+
     Returns None for unsupported paths (caller should skip the field):
       * `$.metadata.constants.X` (descriptor paths)
-      * `.[]` array iteration / slices
+      * a non-trailing `.[]` (per-element field extraction) or array slices
+      * `.[]` over a non-array, or leaving a still-nested array
       * unknown name segments
 
     Raises UnsupportedFeature for an unsupported container path (anything under
@@ -297,7 +303,14 @@ def path_to_dict(
     current = inputs
     leaf_base: str | None = None
     leaf_array_depth = 0
+    saw_array_iter = False
     for element in parsed.elements:
+        if saw_array_iter:
+            # A `.[]` resolves the path to the whole array, which the firmware
+            # formats element-by-element — so nothing may follow it. A per-element
+            # field extraction (`swaps.[].amount`) can't be expressed as a flat
+            # index path, so reject it.
+            return None
         if isinstance(element, PathField):
             name_to_idx = {p.name: i for i, p in enumerate(current) if p.name}
             if element.identifier not in name_to_idx:
@@ -312,7 +325,18 @@ def path_to_dict(
             indices.append(element.index)
             if leaf_array_depth > 0:
                 leaf_array_depth -= 1  # indexing peels one array dimension
-        elif isinstance(element, (Array, ArraySlice)):
+        elif isinstance(element, Array):
+            # `.[]` whole-array iteration. The proto path points at the array
+            # itself (no index appended); the firmware applies the field's
+            # formatter to each element and joins the results. Peel one array
+            # dimension so the leaf kind reflects the per-element type — a leaf
+            # that is still an array (e.g. `uint256[][]`) then classifies as
+            # KIND_OTHER, since only flat arrays of scalars can be iterated.
+            if leaf_array_depth <= 0:
+                return None  # `.[]` on a non-array leaf
+            leaf_array_depth -= 1
+            saw_array_iter = True
+        elif isinstance(element, ArraySlice):
             return None
         else:
             return None
@@ -636,6 +660,7 @@ def build_field_dict(
                 # `_normalize_hex` doesn't validate: a non-hex value would slip
                 # through and crash `bytes.fromhex` at serialization. Reject it
                 # here as an unrepresentable field instead.
+                # TODO: Revisit for a better validation logic. maybe do validate while normalizing.
                 if set(normalized) - _HEX_DIGITS:
                     raise UnsupportedFeature(
                         "invalid-threshold", f"{threshold!r} (field {label!r})"

--- a/eth_definitions/test_erc7730.py
+++ b/eth_definitions/test_erc7730.py
@@ -100,6 +100,46 @@ def test_path_to_dict_unindexed_array_is_other():
     )
 
 
+def test_path_to_dict_array_iteration_peels_to_element_kind():
+    # A trailing `.[]` points the path at the array itself (no extra index); the
+    # returned kind is the per-element type, so a scalar formatter accepts it.
+    assert path_to_dict("amounts.[]", _inputs("f(uint256[] amounts)")) == (
+        {"path": [0]},
+        KIND_NUMERIC,
+    )
+    assert path_to_dict("xs.[]", _inputs("f(address[] xs)")) == (
+        {"path": [0]},
+        KIND_ADDRESS,
+    )
+    assert path_to_dict("ds.[]", _inputs("f(bytes[] ds)")) == (
+        {"path": [0]},
+        KIND_BYTES,
+    )
+
+
+def test_path_to_dict_array_iteration_on_non_array_is_none():
+    assert path_to_dict("x.[]", _inputs("f(uint256 x)")) is None
+
+
+def test_path_to_dict_array_iteration_leaving_nested_array_is_other():
+    # One `.[]` over a 2D array still leaves an array element — not flat-iterable.
+    assert path_to_dict("x.[]", _inputs("f(uint256[][] x)")) == (
+        {"path": [0]},
+        KIND_OTHER,
+    )
+
+
+def test_path_to_dict_double_array_iteration_is_none():
+    # Nothing may follow a `.[]` — including a second `.[]`.
+    assert path_to_dict("x.[].[]", _inputs("f(uint256[][] x)")) is None
+
+
+def test_path_to_dict_non_trailing_array_iteration_is_none():
+    # A per-element field extraction can't be expressed as a flat index path.
+    inputs = _inputs("f((address t, bytes d)[] swaps)")
+    assert path_to_dict("swaps.[].t", inputs) is None
+
+
 def test_path_to_dict_container_paths():
     assert path_to_dict("@.from", []) == ({"container_path": "FROM"}, KIND_ADDRESS)
     assert path_to_dict("@.to", []) == ({"container_path": "TO"}, KIND_ADDRESS)
@@ -732,6 +772,77 @@ def test_date_blockheight_encoding_falls_back_to_raw():
 def test_date_on_non_numeric_skips_file():
     desc = _single_field_desc(
         "f(address x)", {"path": "x", "label": "L", "format": "date"}
+    )
+    unsupported: list = []
+    with pytest.raises(UnsupportedFeature):
+        build_display_formats(desc, unsupported=unsupported)
+    assert {feat for _src, feat, _det in unsupported} == {"formatter-type-mismatch"}
+
+
+# =====================================================================
+#                array (multi-value) formatters via `.[]`
+# =====================================================================
+
+
+def test_amount_over_array_is_kept():
+    # `amounts.[]` renders the amount formatter once per array element on-device;
+    # the emitted path points at the array itself.
+    desc = _single_field_desc(
+        "f(uint256[] amounts)",
+        {"path": "amounts.[]", "label": "Amounts", "format": "unit", "params": {"decimals": 9}},
+    )
+    [rec] = build_display_formats(desc)
+    [field] = rec["field_definitions"]
+    assert field["path"] == {"path": [0]}
+    assert field["formatter"] == "FORMATTER_UNIT"
+
+
+def test_addressname_over_array_is_kept():
+    desc = _single_field_desc(
+        "f(address[] recipients)",
+        {"path": "recipients.[]", "label": "To", "format": "addressName"},
+    )
+    [rec] = build_display_formats(desc)
+    assert rec["field_definitions"][0]["formatter"] == "FORMATTER_ADDRESS_NAME"
+
+
+def test_raw_over_array_is_kept():
+    desc = _single_field_desc(
+        "f(bytes[] datas)", {"path": "datas.[]", "label": "Data", "format": "raw"}
+    )
+    [rec] = build_display_formats(desc)
+    assert rec["field_definitions"][0]["formatter"] == "FORMATTER_RAW"
+
+
+def test_tokenamount_over_array_with_shared_token_path():
+    # An array of amounts sharing a single token: the amount path iterates, the
+    # token_path resolves to one (scalar) token address.
+    desc = _descriptor(
+        formats={
+            "f(uint256[] amounts, address token)": {
+                "fields": [
+                    {
+                        "path": "amounts.[]",
+                        "label": "Amounts",
+                        "format": "tokenAmount",
+                        "params": {"tokenPath": "token"},
+                    }
+                ]
+            }
+        }
+    )
+    [rec] = build_display_formats(desc)
+    [field] = rec["field_definitions"]
+    assert field["path"] == {"path": [0]}
+    assert field["formatter"] == "FORMATTER_TOKEN_AMOUNT"
+    assert field["token_path"] == {"path": [1]}
+
+
+def test_unindexed_array_without_iteration_skips_file():
+    # A bare array path (no `.[]`) is still unrenderable.
+    desc = _single_field_desc(
+        "f(uint256[] amounts)",
+        {"path": "amounts", "label": "Amounts", "format": "amount"},
     )
     unsupported: list = []
     with pytest.raises(UnsupportedFeature):

--- a/eth_definitions/test_erc7730.py
+++ b/eth_definitions/test_erc7730.py
@@ -346,8 +346,61 @@ def test_tokenpath_non_address_skips_file():
     assert {feat for _src, feat, _det in unsupported} == {"unresolvable-token-path"}
 
 
-def test_tokenamount_hardcoded_token_skips_file():
-    # A literal `token` address can't be encoded as a token_path — skip the file.
+def _const_token_desc(token, constants=None):
+    return _descriptor(
+        formats={
+            "f(uint256 amount)": {
+                "fields": [
+                    {
+                        "path": "amount",
+                        "label": "Amt",
+                        "format": "tokenAmount",
+                        "params": {"token": token},
+                    }
+                ]
+            }
+        },
+        constants=constants,
+    )
+
+
+def test_tokenamount_literal_token_is_const_token_address():
+    # A literal `token` address is emitted directly as const_token_address.
+    [rec] = build_display_formats(_const_token_desc("0x" + "ab" * 20))
+    [field] = rec["field_definitions"]
+    assert field["formatter"] == "FORMATTER_TOKEN_AMOUNT"
+    assert field["const_token_address"] == "ab" * 20
+    assert "token_path" not in field
+
+
+def test_tokenamount_constant_ref_token_is_resolved():
+    # The token may be a $.metadata.constants.* reference resolved by the parser.
+    desc = _const_token_desc(
+        "$.metadata.constants.usdc", constants={"usdc": "0x" + "cd" * 20}
+    )
+    [rec] = build_display_formats(desc)
+    assert rec["field_definitions"][0]["const_token_address"] == "cd" * 20
+
+
+def test_tokenamount_invalid_const_token_skips_file():
+    unsupported: list = []
+    with pytest.raises(UnsupportedFeature):
+        build_display_formats(_const_token_desc("not-an-address"), unsupported=unsupported)
+    assert {feat for _src, feat, _det in unsupported} == {"invalid-const-token"}
+
+
+def test_tokenamount_unresolvable_constant_token_skips_file():
+    # A $.metadata.constants.* reference with no matching constant is invalid.
+    unsupported: list = []
+    with pytest.raises(UnsupportedFeature):
+        build_display_formats(
+            _const_token_desc("$.metadata.constants.missing"), unsupported=unsupported
+        )
+    assert {feat for _src, feat, _det in unsupported} == {"invalid-const-token"}
+
+
+def test_tokenamount_literal_zero_token_with_native_is_amount():
+    # A literal zero token is the null/native token: native AMOUNT when declared.
     desc = _descriptor(
         formats={
             "f(uint256 amount)": {
@@ -356,16 +409,62 @@ def test_tokenamount_hardcoded_token_skips_file():
                         "path": "amount",
                         "label": "Amt",
                         "format": "tokenAmount",
-                        "params": {"token": "0x" + "ab" * 20},
+                        "params": {
+                            "token": "0x" + "00" * 20,
+                            "nativeCurrencyAddress": ["0x" + "00" * 20],
+                        },
                     }
                 ]
             }
         }
     )
+    [rec] = build_display_formats(desc)
+    [field] = rec["field_definitions"]
+    assert field["formatter"] == "FORMATTER_AMOUNT"
+    assert "const_token_address" not in field
+
+
+def test_tokenamount_literal_zero_token_without_native_skips_file():
     unsupported: list = []
     with pytest.raises(UnsupportedFeature):
-        build_display_formats(desc, unsupported=unsupported)
-    assert {feat for _src, feat, _det in unsupported} == {"tokenamount-hardcoded-token"}
+        build_display_formats(_const_token_desc("0x" + "00" * 20), unsupported=unsupported)
+    assert {feat for _src, feat, _det in unsupported} == {"tokenamount-unknown-token"}
+
+
+def test_tokenamount_const_token_keeps_threshold():
+    desc = _descriptor(
+        formats={
+            "f(uint256 amount)": {
+                "fields": [
+                    {
+                        "path": "amount",
+                        "label": "Amt",
+                        "format": "tokenAmount",
+                        "params": {"token": "0x" + "ab" * 20, "threshold": "0xff"},
+                    }
+                ]
+            }
+        }
+    )
+    [rec] = build_display_formats(desc)
+    [field] = rec["field_definitions"]
+    assert field["const_token_address"] == "ab" * 20
+    assert field["threshold"] == "ff"
+
+
+def test_const_token_address_serializes_to_proto():
+    # The const_token_address hex makes it onto the proto field as raw bytes.
+    from .common import _build_erc7730_field_info
+
+    info = _build_erc7730_field_info(
+        {
+            "path": {"path": [0]},
+            "label": "Amt",
+            "formatter": "FORMATTER_TOKEN_AMOUNT",
+            "const_token_address": "ab" * 20,
+        }
+    )
+    assert info.const_token_address == bytes.fromhex("ab" * 20)
 
 
 def _tokenamount_native_desc(native_addresses, constants=None):

--- a/eth_definitions/test_erc7730.py
+++ b/eth_definitions/test_erc7730.py
@@ -6,6 +6,7 @@ from erc7730.model.abi import Component
 
 from .erc7730 import (
     KIND_ADDRESS,
+    KIND_BYTES,
     KIND_NUMERIC,
     KIND_OTHER,
     UnsupportedFeature,
@@ -64,11 +65,12 @@ def test_path_to_dict_numeric():
     )
 
 
-def test_path_to_dict_other_for_bytes():
-    assert path_to_dict("data", _inputs("f(bytes data)")) == (
-        {"path": [0]},
-        KIND_OTHER,
-    )
+def test_path_to_dict_bytes_and_string_and_bool_are_kind_bytes():
+    # Scalar bytes/string/bool leaves are renderable only by `raw`.
+    assert path_to_dict("data", _inputs("f(bytes data)")) == ({"path": [0]}, KIND_BYTES)
+    assert path_to_dict("s", _inputs("f(string s)")) == ({"path": [0]}, KIND_BYTES)
+    assert path_to_dict("ok", _inputs("f(bool ok)")) == ({"path": [0]}, KIND_BYTES)
+    assert path_to_dict("h", _inputs("f(bytes32 h)")) == ({"path": [0]}, KIND_BYTES)
 
 
 def test_path_to_dict_into_tuple():
@@ -561,6 +563,81 @@ def test_unit_non_numeric_decimals_skips_file():
     )
     with pytest.raises(UnsupportedFeature):
         build_display_formats(desc)
+
+
+# =====================================================================
+#                       raw / date formatters
+# =====================================================================
+
+
+def _single_field_desc(signature, field):
+    return _descriptor(formats={signature: {"fields": [field]}})
+
+
+@pytest.mark.parametrize(
+    "signature",
+    [
+        "f(uint256 x)",
+        "f(address x)",
+        "f(bytes x)",
+        "f(bytes32 x)",
+        "f(string x)",
+        "f(bool x)",
+    ],
+)
+def test_raw_renders_any_scalar_leaf(signature):
+    # `raw` accepts every scalar leaf kind (numeric/address/bytes/string/bool).
+    desc = _single_field_desc(signature, {"path": "x", "label": "L", "format": "raw"})
+    [rec] = build_display_formats(desc)
+    assert rec["field_definitions"][0]["formatter"] == "FORMATTER_RAW"
+
+
+def test_raw_on_whole_array_skips_file():
+    # An un-indexed array is not a single value, so even `raw` can't render it.
+    desc = _single_field_desc(
+        "f(uint256[] xs)", {"path": "xs", "label": "L", "format": "raw"}
+    )
+    unsupported: list = []
+    with pytest.raises(UnsupportedFeature):
+        build_display_formats(desc, unsupported=unsupported)
+    assert {feat for _src, feat, _det in unsupported} == {"formatter-type-mismatch"}
+
+
+def test_date_default_encoding_is_date_formatter():
+    desc = _single_field_desc(
+        "f(uint256 t)", {"path": "t", "label": "Deadline", "format": "date"}
+    )
+    [rec] = build_display_formats(desc)
+    assert rec["field_definitions"][0]["formatter"] == "FORMATTER_DATE"
+
+
+def test_date_timestamp_encoding_is_date_formatter():
+    desc = _single_field_desc(
+        "f(uint256 t)",
+        {"path": "t", "label": "Deadline", "format": "date", "params": {"encoding": "timestamp"}},
+    )
+    [rec] = build_display_formats(desc)
+    assert rec["field_definitions"][0]["formatter"] == "FORMATTER_DATE"
+
+
+def test_date_blockheight_encoding_falls_back_to_raw():
+    # A block number is not a time — render it as a plain integer, not a date.
+    desc = _single_field_desc(
+        "f(uint256 b)",
+        {"path": "b", "label": "Block", "format": "date", "params": {"encoding": "blockheight"}},
+    )
+    [rec] = build_display_formats(desc)
+    assert rec["field_definitions"][0]["formatter"] == "FORMATTER_RAW"
+
+
+def test_date_on_non_numeric_skips_file():
+    desc = _single_field_desc(
+        "f(address x)", {"path": "x", "label": "L", "format": "date"}
+    )
+    unsupported: list = []
+    with pytest.raises(UnsupportedFeature):
+        build_display_formats(desc, unsupported=unsupported)
+    assert {feat for _src, feat, _det in unsupported} == {"formatter-type-mismatch"}
 
 
 # =====================================================================


### PR DESCRIPTION
- ~Manually inspecting the definitions rn. Logs look good.~
- Done. verified the parsed definitions with the json ones. No issues found.