### PR TITLE
Clear signing: metadata constant value path support (re-land of #61)

### DIFF
--- a/eth_definitions/common.py
+++ b/eth_definitions/common.py
@@ -39,8 +39,7 @@ except ImportError as e:
     ) from None
 
 
-# A trezorlib that predates the ERC-7730 clear-signing proto additions (the
-# FORMATTER_RAW / FORMATTER_DATE enum members and the const_token_address field)
+# A trezorlib that predates the ERC-7730 clear-signing proto additions
 # imports fine but is missing them — which would otherwise surface only as a
 # cryptic KeyError deep inside serialization. Fail fast with the same guidance.
 _missing_proto = [
@@ -52,6 +51,10 @@ if not any(
     f.name == "const_token_address" for f in EthereumERC7730FieldInfo.FIELDS.values()
 ):
     _missing_proto.append("EthereumERC7730FieldInfo.const_token_address")
+if not any(
+    f.name == "const_value" for f in EthereumERC7730Path.FIELDS.values()
+):
+    _missing_proto.append("EthereumERC7730Path.const_value")
 if _missing_proto:
     raise SystemExit(
         "Your trezorlib is outdated — missing " + ", ".join(_missing_proto) + ".\n"
@@ -193,7 +196,11 @@ class _DataPath(t.TypedDict):
     path: list[int]
 
 
-ERC7730Path = _ContainerPath | _DataPath
+class _ConstValuePath(t.TypedDict):
+    const_value: str  # a literal constant value, not walked from calldata
+
+
+ERC7730Path = _ContainerPath | _DataPath | _ConstValuePath
 
 
 class ERC7730Field(t.TypedDict):
@@ -334,7 +341,7 @@ def _serialize_solana_token(token: SolanaToken, timestamp: int) -> bytes:
 
 
 _ABI_VARIANT_KEYS = frozenset({"atomic", "dynamic", "tuple", "array"})
-_PATH_VARIANT_KEYS = frozenset({"container_path", "path"})
+_PATH_VARIANT_KEYS = frozenset({"container_path", "path", "const_value"})
 
 
 def _build_abi_value_info(d: ABIValue) -> EthereumABIValueInfo:
@@ -372,6 +379,8 @@ def _build_erc7730_path(d: ERC7730Path) -> EthereumERC7730Path:
         )
     if "path" in d:
         return EthereumERC7730Path(path=list(d["path"]))
+    if "const_value" in d:
+        return EthereumERC7730Path(const_value=d["const_value"])
     raise AssertionError("unreachable")
 
 

--- a/eth_definitions/erc7730.py
+++ b/eth_definitions/erc7730.py
@@ -535,6 +535,46 @@ def _field_is_displayed(field_def: dict[str, Any]) -> bool:
     return field_def.get("visible") not in (False, "never")
 
 
+def build_const_field(
+    field_def: dict[str, Any],
+    constants: dict[str, Any],
+) -> ERC7730Field | None:
+    """Build a field bound to a constant `value` (no calldata `path`).
+
+    ERC-7730 `raw` fields may carry a literal `value` (or a
+    `$.metadata.constants.*` reference) instead of a `path` — a static label
+    such as a vault's share ticker. The device shows it via the RAW formatter
+    from a `const_value` path (nothing is walked from calldata), so resolve the
+    value to a string here.
+
+    Returns None if the field isn't a representable constant (not `raw`, no
+    label, missing `value`, or an unresolvable constant reference) — the caller
+    then treats it as an unsupported non-path field.
+    """
+    # Only `raw` constants are representable: the device renders `const_value`
+    # via the RAW formatter (a string as-is); other formatters need a typed
+    # calldata value.
+    if field_def.get("format") != "raw":
+        return None
+    label = field_def.get("label", "")
+    if not label:
+        return None
+    value = field_def.get("value")
+    if value is None:
+        return None
+    s = str(value)
+    if s.startswith("$"):
+        resolved = _resolve_constant(s, constants)
+        if resolved is None:
+            return None
+        s = str(resolved)
+    return {
+        "path": {"const_value": s},
+        "label": label,
+        "formatter": _FORMATTER_MAP["raw"],
+    }
+
+
 def build_field_dict(
     field_def: dict[str, Any],
     inputs: list[Component],
@@ -842,13 +882,19 @@ def build_display_formats(
                 note("nested-fields", f"{sig_key}: path {f.get('path')!r}")
                 continue
             if "path" not in f:
-                # Constant/text field (`format: raw` with a `value`) or similar —
-                # a displayed field not bound to a calldata parameter.
+                # A displayed field not bound to a calldata parameter. A `raw`
+                # constant (`value` literal or `$.metadata.constants.*` ref) is
+                # emitted as a const_value field; anything else is unrepresentable
+                # and drops this display format.
                 if _field_is_displayed(f):
-                    note(
-                        "non-path-field",
-                        f"{sig_key}: {f.get('format')} (label {f.get('label')!r})",
-                    )
+                    const_field = build_const_field(f, constants)
+                    if const_field is not None:
+                        field_defs.append(const_field)
+                    else:
+                        note(
+                            "non-path-field",
+                            f"{sig_key}: {f.get('format')} (label {f.get('label')!r})",
+                        )
                 continue
             try:
                 built = build_field_dict(

--- a/eth_definitions/test_erc7730.py
+++ b/eth_definitions/test_erc7730.py
@@ -12,6 +12,7 @@ from .erc7730 import (
     UnsupportedFeature,
     _resolve_ref,
     build_abi_value,
+    build_const_field,
     build_display_formats,
     path_to_dict,
 )
@@ -851,6 +852,95 @@ def test_unindexed_array_without_iteration_skips_file():
 
 
 # =====================================================================
+#                  constant (non-path) value fields
+# =====================================================================
+
+
+def test_build_const_field_literal():
+    assert build_const_field({"label": "Note", "format": "raw", "value": "Hello"}, {}) == {
+        "path": {"const_value": "Hello"},
+        "label": "Note",
+        "formatter": "FORMATTER_RAW",
+    }
+
+
+def test_build_const_field_constant_ref_is_resolved():
+    field = {"label": "Share ticker", "format": "raw", "value": "$.metadata.constants.vaultTicker"}
+    assert build_const_field(field, {"vaultTicker": "kmgcEURC"}) == {
+        "path": {"const_value": "kmgcEURC"},
+        "label": "Share ticker",
+        "formatter": "FORMATTER_RAW",
+    }
+
+
+def test_build_const_field_unresolvable_ref_is_none():
+    field = {"label": "X", "format": "raw", "value": "$.metadata.constants.missing"}
+    assert build_const_field(field, {}) is None
+
+
+def test_build_const_field_non_raw_format_is_none():
+    # Only `raw` constants are representable (rendered as a string on-device).
+    assert build_const_field({"label": "X", "format": "amount", "value": "5"}, {}) is None
+
+
+def test_build_const_field_missing_value_or_label_is_none():
+    assert build_const_field({"label": "X", "format": "raw"}, {}) is None
+    assert build_const_field({"format": "raw", "value": "hi"}, {}) is None
+
+
+def test_const_field_end_to_end_keeps_display_format():
+    # kiln-style deposit: an amount, a constant "Share ticker" label, a recipient.
+    # The constant no longer drops the whole display format.
+    desc = _descriptor(
+        formats={
+            "deposit(uint256 assets, address receiver)": {
+                "fields": [
+                    {"path": "assets", "label": "Deposit asset", "format": "tokenAmount",
+                     "params": {"token": "0x" + "ab" * 20}},
+                    {"label": "Share ticker", "format": "raw",
+                     "value": "$.metadata.constants.vaultTicker"},
+                    {"path": "receiver", "label": "Send shares to", "format": "addressName"},
+                ]
+            }
+        },
+        constants={"vaultTicker": "kmgcEURC"},
+    )
+    [rec] = build_display_formats(desc)
+    fields = rec["field_definitions"]
+    assert len(fields) == 3
+    assert fields[1] == {
+        "path": {"const_value": "kmgcEURC"},
+        "label": "Share ticker",
+        "formatter": "FORMATTER_RAW",
+    }
+
+
+def test_const_value_serializes_to_proto():
+    from .common import _build_erc7730_field_info
+
+    info = _build_erc7730_field_info(
+        {
+            "path": {"const_value": "kmgcEURC"},
+            "label": "Share ticker",
+            "formatter": "FORMATTER_RAW",
+        }
+    )
+    assert info.path.const_value == "kmgcEURC"
+
+
+def test_non_raw_non_path_field_still_drops_format():
+    # A displayed non-path field that isn't a resolvable `raw` constant remains
+    # unrepresentable and drops the display format.
+    desc = _descriptor(
+        formats={"f(uint256 x)": {"fields": [{"label": "X", "format": "amount", "value": "5"}]}}
+    )
+    unsupported: list = []
+    with pytest.raises(UnsupportedFeature):
+        build_display_formats(desc, unsupported=unsupported)
+    assert {feat for _src, feat, _det in unsupported} == {"non-path-field"}
+
+
+# =====================================================================
 #       build_display_formats — file skip, collection, hidden fields
 # =====================================================================
 
@@ -866,15 +956,19 @@ def test_unsupported_formatter_skips_file_and_is_collected():
     assert unsupported[0][1] == "unsupported-formatter"
 
 
-def test_raw_constant_field_skips_file():
-    # A displayed field bound to a constant (no calldata `path`).
+def test_raw_constant_field_is_emitted():
+    # A displayed `raw` field bound to a literal constant (no calldata `path`) is
+    # emitted as a const_value field rather than dropping the display format.
     desc = _descriptor(
         formats={"f(uint256 x)": {"fields": [{"label": "Summary", "format": "raw", "value": "hi"}]}}
     )
-    unsupported: list = []
-    with pytest.raises(UnsupportedFeature):
-        build_display_formats(desc, unsupported=unsupported)
-    assert {feat for _src, feat, _det in unsupported} == {"non-path-field"}
+    [rec] = build_display_formats(desc)
+    [field] = rec["field_definitions"]
+    assert field == {
+        "path": {"const_value": "hi"},
+        "label": "Summary",
+        "formatter": "FORMATTER_RAW",
+    }
 
 
 def test_nested_field_group_skips_file():


### PR DESCRIPTION
## What

Re-lands #61 onto `main`, unchanged. This is a straight cherry-pick of its squash commit (`b6b2fc3`) on top of current `main` — the diff is byte-identical to what was already reviewed and approved there.

## Why a re-land

#61 was stacked on #60's head branch (`prisionmike/add-more-cs-formatters`) and its base was never retargeted after #60 was squash-merged. When #61 was merged, its content therefore landed on the stale feature branch instead of `main` and never reached it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)