### PR TITLE
Add `computed_merkle_root` command to cli.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This script will automatically create a commit with these changes.
 To prevent incorrect/malicious definitions from being supplied to `Trezor`, they need to be signed before using them.
 
 Signing has the following steps:
-- get the `merkle_root` value stored in `definitions-latest.json::metadata::merkle_root` manually or by running `python cli.py current-merkle-root`
+- run `python cli.py computed-merkle-root` to get the `merkle_root` computed from the definitions data rather than trusting the value stored in `definitions-latest.json::metadata::merkle_root`
 - sign it with appropriate keys (outside of definitions repo)
 - get the signature and provide it as an argument to `do_sign.sh`, e.g. `./do_sign.sh abcd...`
 - the results should look something like this signing commit - https://github.com/trezor/definitions/commit/42d3093e83c85dade59af92a37fb3c33d3b047eb

--- a/cli.py
+++ b/cli.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import click
 
 from eth_definitions.builtin_defs import check_builtin
-from eth_definitions.common import load_definitions_data
+from eth_definitions.common import get_merkle_root, load_definitions_data
 from eth_definitions.download import download
 from eth_definitions.generate import generate_definitions
 from eth_definitions.sign import sign_definitions
@@ -27,6 +27,27 @@ def current_merkle_root():
     Used in the shell script instead of having to get jq."""
     metadata, _ = load_definitions_data()
     print(metadata["merkle_root"])
+
+
+@cli.command()
+def computed_merkle_root():
+    """Recompute the Merkle root from the definitions data.
+
+    Unlike current-merkle-root, this does not trust the value stored in
+    metadata but derives it from the definitions themselves. A warning is
+    emitted if the two disagree (the stored value is stale or tampered)."""
+    metadata, definitions_data = load_definitions_data()
+    computed = get_merkle_root(definitions_data, metadata["unix_timestamp"])
+    stored = metadata.get("merkle_root")
+    if stored is not None and stored != computed:
+        click.echo(
+            "WARNING: computed Merkle root does not match the one stored in "
+            "definitions-latest.json:\n"
+            f"  computed: {computed}\n"
+            f"  stored:   {stored}",
+            err=True,
+        )
+    print(computed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a command which recomputes the Merkle root from the definitions data, unlike `current-merkle-root` which trusts the value stored in metadata. The `merkle_root` field in `definitions-latest.json` is just an unverified claim. Nothing ties it to the actual definitions data until someone recomputes it. If it were wrong due to tampering, or a bug in an earlier step we'd be producing a valid signature over a root that doesn't match the definitions being shipped. Signing the value produced by `computed-merkle-root` rather than the one produced by `current-merkle-root` means we sign what we can see, not the opaque value claimed in the json file. The `current-merkle-root` command stays for cases where you only need the stored value