### PR TITLE
feat: introduce definitions version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,23 @@ When adding definitions for another coin, add a new `definitions/<coin>/` subpac
 
 This script will automatically create a commit with these changes.
 
+## Versioning
+
+`definitions-latest.json::metadata::version` is an integer version of the whole definitions blob. Historical blobs without the field are equivalent to version 1.
+
+Bump it with `python cli.py bump-version` (or `bump-version N` to set it explicitly) on any **backward-incompatible** change, e.g.:
+
+- an ERC-7730 clear-signing serialization/parsing change (see [trezor-firmware#7496](https://github.com/trezor/trezor-firmware/issues/7496)),
+- a change of the signing scheme (e.g. reducing the CoSi signature quorum).
+
+The version is carried forward across `download` runs automatically; bumping is always a deliberate, manual act.
+
+Notes:
+
+- The version is **not** part of the signed Merkle root, so bumping it alone does not require re-signing. If the bump accompanies a serialization change, the Merkle root changes and the definitions must be re-signed as usual.
+- `unix_timestamp` is independent of the version and remains the freshness gate used by firmware (including legacy Model One) to progressively deprecate old definitions.
+- Client applications (Connect/Suite) use the version to serve firmware-specific definitions (e.g. under a versioned path), and new firmware may reject older definitions by requiring a minimum timestamp at a format cutover.
+
 ## Signing procedure
 
 To prevent incorrect/malicious definitions from being supplied to `Trezor`, they need to be signed before using them.

--- a/cli.py
+++ b/cli.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 import click
 
-from definitions.common import load_definitions_data
+from definitions.common import (
+    DEFINITIONS_FORMAT_VERSION,
+    load_definitions_data,
+    store_definitions_data,
+)
 from definitions.download import download
 from definitions.ethereum.builtin_defs import check_builtin
 from definitions.generate import generate_definitions
@@ -49,6 +53,31 @@ def computed_merkle_root():
             err=True,
         )
     print(computed)
+
+
+@cli.command()
+@click.argument("version", required=False, type=int)
+def bump_version(version: int | None) -> None:
+    """Bump the definitions blob version stored in metadata.
+
+    Without an argument, increments the current version by one; an explicit
+    VERSION argument sets it directly. Use this on any backward-incompatible
+    change (e.g. ERC-7730 serialization changes, signing-scheme changes).
+
+    The version is not part of the signed Merkle root, so no re-signing is
+    needed after bumping it alone. If the bump accompanies a serialization
+    change, the Merkle root changes and the definitions must be re-signed.
+    """
+    metadata, definitions_data = load_definitions_data()
+    current = metadata.get("version", DEFINITIONS_FORMAT_VERSION)
+    new = version if version is not None else current + 1
+    if new <= current:
+        raise click.ClickException(
+            f"New version ({new}) must be greater than the current one ({current})."
+        )
+    metadata["version"] = new
+    store_definitions_data(metadata, definitions_data)
+    click.echo(f"Definitions blob version bumped: {current} -> {new}")
 
 
 if __name__ == "__main__":

--- a/definitions/common.py
+++ b/definitions/common.py
@@ -50,6 +50,14 @@ CURRENT_TIMESTAMP_STR = CURRENT_TIME.strftime(TIMESTAMP_FORMAT)
 
 FORMAT_VERSION_BYTES = b"trzd1"
 
+# Version of the whole definitions blob, stored in `metadata.version`.
+# Absent version in older blobs means the same as version 1.
+# Bump it (via `cli.py bump-version`) on any backward-incompatible change,
+# e.g. an ERC-7730 serialization change or a signing-scheme change.
+# Independent from `unix_timestamp`, which remains the freshness gate used
+# by firmware to progressively deprecate old definitions.
+DEFINITIONS_FORMAT_VERSION = 1
+
 
 class ChangeResolutionStrategy(Enum):
     REJECT_ALL_CHANGES = 1
@@ -77,6 +85,7 @@ class DefinitionsFileMetadata(t.TypedDict):
     merkle_root: str
     commit_hash: str
     signature: t.NotRequired[str]
+    version: t.NotRequired[int]
 
 
 class DefinitionsFileFormat(t.TypedDict):

--- a/definitions/serialize.py
+++ b/definitions/serialize.py
@@ -11,7 +11,14 @@ import typing as t
 
 from trezorlib.merkle_tree import MerkleTree
 
-from .common import DefinitionsData, DefinitionsFileMetadata, get_git_commit_hash
+from .common import (
+    DEFINITIONS_FORMAT_VERSION,
+    DEFINITIONS_PATH,
+    DefinitionsData,
+    DefinitionsFileMetadata,
+    get_git_commit_hash,
+    load_json_file,
+)
 from .ethereum import serialize as ethereum_serialize
 from .ethereum.types import ERC20DisplayFormat, ERC20Token, Network
 from .solana import serialize as solana_serialize
@@ -60,17 +67,31 @@ def serialize_definitions(
     }
 
 
+def _load_current_version() -> int:
+    """Carry forward the blob version from the existing definitions file."""
+    try:
+        metadata = load_json_file(DEFINITIONS_PATH)["metadata"]
+        return int(metadata.get("version", DEFINITIONS_FORMAT_VERSION))
+    except (OSError, KeyError, TypeError, ValueError):
+        return DEFINITIONS_FORMAT_VERSION
+
+
 def make_metadata(
-    definitions_data: DefinitionsData, now: datetime.datetime | None = None
+    definitions_data: DefinitionsData,
+    now: datetime.datetime | None = None,
+    version: int | None = None,
 ) -> DefinitionsFileMetadata:
     if now is None:
         now = datetime.datetime.now(datetime.timezone.utc)
     timestamp = int(now.timestamp())
     time_str = now.isoformat()
     merkle_root = get_merkle_root(definitions_data, timestamp)
+    if version is None:
+        version = _load_current_version()
     return DefinitionsFileMetadata(
         datetime=time_str,
         unix_timestamp=timestamp,
         merkle_root=merkle_root,
         commit_hash=get_git_commit_hash(),
+        version=version,
     )


### PR DESCRIPTION
This PR adds `metadata["version"]` to the definitions blob which should be used by Connect to serve the right definitions. This way, the version is not enforced cryptographically as the `version` is not a part of the signature.

However, we already have two other mechanisms:
- timestamp: I believe this can stay to make sure the FW gets fresh data on the current version, if the `version` doesn't change for a long time. Keeping the timestamp and having the new `version` separated also allows us not to change legacy FW.
- blob `magic`: currently, we use `trzd1` and we may increment to `trzd2`. Changing the blob would change the signature  would require coordination of FW and Trezorlib release. This may potentially be reserved for a more significant change