### PR TITLE
fix: name in HyperEVM override

### DIFF
--- a/definitions/ethereum/load.py
+++ b/definitions/ethereum/load.py
@@ -92,6 +92,8 @@ NETWORK_OVERRIDES: dict[int, Network] = {
         name="HyperEVM",
         shortcut="HYPE",
         slip44=60,
+        coingecko_id="hyperliquid",
+        coingecko_network_id="hyperevm",
     ),
 }
 


### PR DESCRIPTION
- NETWORK_OVERRIDES[999] set name "HyperEVM", but the generated definitions showed "Hyperliquid": download.py maps the CoinGecko native coin ("hyperliquid") back to the network and unconditionally overwrites network name/shortcut with the coin's.
- Pin coingecko_id/coingecko_network_id directly in NETWORK_OVERRIDES. With coingecko_id pre-set, download.py skips its platform lookup for chain 999, so the network is never registered for enrichment and the name survives.
- Both fields must be pinned: setting only coingecko_id would also skip the DeFiLlama fallback, leaving coingecko_network_id unset and breaking token downloads and the network_to_cid mapping for the chain.


This is a correction PR of https://github.com/trezor/definitions/pull/73 and subsequently #83  which didn't re-target to `main` after the base branch was merged..