### PR TITLE
Fix Aave and yield.xyz

### DIFF
--- a/definitions/ethereum/erc7730.py
+++ b/definitions/ethereum/erc7730.py
@@ -1070,7 +1070,7 @@ def _build_path_field(
     if fmt == "tokenAmount":
         _apply_token_amount_params(out, params, path_str, label, ctx)
     elif fmt == "unit":
-        _apply_unit_params(out, params, label)
+        _apply_unit_params(out, params, label, ctx)
     elif fmt == "date":
         _apply_date_params(out, params, path_str, label, ctx)
     elif fmt == "calldata":
@@ -1186,7 +1186,7 @@ def _apply_threshold(
 ) -> None:
     """Normalize a `threshold` param to hex bytes; reject the unserializable."""
     threshold = params.get("threshold")
-    if isinstance(threshold, str) and threshold.startswith("$"):
+    if isinstance(threshold, str) and threshold.startswith("$."):
         resolved = _resolve_constant(threshold, constants)
         if resolved is None:
             raise UnsupportedFeature(
@@ -1212,7 +1212,9 @@ def _apply_threshold(
         out["threshold"] = _normalize_hex(hex(threshold))
 
 
-def _apply_unit_params(out: ERC7730Field, params: dict[str, Any], label: str) -> None:
+def _apply_unit_params(
+    out: ERC7730Field, params: dict[str, Any], label: str, ctx: _FormatContext
+) -> None:
     """Copy FORMATTER_UNIT's decimals / base / prefix params."""
     if params.get("decimals") is not None:
         try:
@@ -1228,8 +1230,16 @@ def _apply_unit_params(out: ERC7730Field, params: dict[str, Any], label: str) ->
                 f"{decimals} out of uint32 range (field {label!r})",
             )
         out["decimals"] = decimals
-    if params.get("base"):
-        out["base"] = str(params["base"])
+    base = params.get("base")
+    if base:
+        if isinstance(base, str) and base.startswith("$."):
+            resolved = _resolve_constant(base, ctx.constants)
+            if resolved is None:
+                raise UnsupportedFeature(
+                    "unresolvable-constant-value", f"{base!r} (field {label!r})"
+                )
+            base = resolved
+        out["base"] = str(base)
     if params.get("prefix") is not None:
         out["prefix"] = bool(params["prefix"])
 

--- a/definitions/ethereum/test_erc7730.py
+++ b/definitions/ethereum/test_erc7730.py
@@ -965,6 +965,75 @@ def test_unit_non_numeric_decimals_skips_file():
         build_display_formats(desc)
 
 
+def test_unit_base_literal_is_kept():
+    desc = _descriptor(
+        formats={
+            "f(uint256 x)": {
+                "fields": [
+                    {
+                        "path": "x",
+                        "label": "Stake amount",
+                        "format": "unit",
+                        "params": {"base": "POL", "decimals": 18},
+                    }
+                ]
+            }
+        }
+    )
+    [rec] = build_display_formats(desc)
+    assert rec["field_definitions"][0]["base"] == "POL"
+
+
+def test_unit_base_constant_ref_is_resolved():
+    # `base` may be a $.metadata.constants.* reference (yieldxyz staking tokens).
+    desc = _descriptor(
+        formats={
+            "f(uint256 x)": {
+                "fields": [
+                    {
+                        "path": "x",
+                        "label": "Stake amount",
+                        "format": "unit",
+                        "params": {
+                            "base": "$.metadata.constants.stakingTokenTicker",
+                            "decimals": 18,
+                        },
+                    }
+                ]
+            }
+        },
+        constants={"stakingTokenTicker": "POL"},
+    )
+    [rec] = build_display_formats(desc)
+    assert rec["field_definitions"][0]["base"] == "POL"
+
+
+def test_unit_base_unresolvable_constant_ref_skips_file():
+    unsupported: list = []
+    desc = _descriptor(
+        formats={
+            "f(uint256 x)": {
+                "fields": [
+                    {
+                        "path": "x",
+                        "label": "Stake amount",
+                        "format": "unit",
+                        "params": {
+                            "base": "$.metadata.constants.missing",
+                            "decimals": 18,
+                        },
+                    }
+                ]
+            }
+        }
+    )
+    with pytest.raises(UnsupportedFeature):
+        build_display_formats(desc, unsupported=unsupported)
+    assert {feat for _src, feat, _det in unsupported} == {
+        "unresolvable-constant-value"
+    }
+
+
 # =====================================================================
 #                       raw / date formatters
 # =====================================================================


### PR DESCRIPTION
Update registry commit (Upstream includes aave fix)

Fixed unit formatter to also carry `Formatter context`. Fixes #86 